### PR TITLE
Redirection handling changes

### DIFF
--- a/qgiscommons2/network/networkaccessmanager.py
+++ b/qgiscommons2/network/networkaccessmanager.py
@@ -51,6 +51,9 @@ class RequestsExceptionConnectionError(RequestsException):
 class RequestsExceptionUserAbort(RequestsException):
     pass
 
+class RequestsMaxRedirects(RequestsException):
+    pass
+
 class Map(dict):
     """
     Example:
@@ -338,6 +341,7 @@ class NetworkAccessManager(object):
                 self.reply = None
                 
                 if self.calling_args['redirections'] <= 0:
+                    self.http_call_result.exception = RequestsMaxRedirects("Network error: Exceeded maximum redirects")
                     return
                 
                 new_request = {}

--- a/qgiscommons2/network/networkaccessmanager.py
+++ b/qgiscommons2/network/networkaccessmanager.py
@@ -37,7 +37,6 @@ from qgis.core import (
     QgsMessageLog
 )
 
-# FIXME: ignored
 DEFAULT_MAX_REDIRECTS = 4
 
 class RequestsException(Exception):
@@ -174,8 +173,10 @@ class NetworkAccessManager(object):
     def request(self, url, method="GET", body=None, headers=None, redirections=DEFAULT_MAX_REDIRECTS, connection_type=None, blocking=True):
         """
         Make a network request by calling QgsNetworkAccessManager.
-        redirections argument is ignored and is here only for httplib2 compatibility.
         """
+        self.calling_args = locals()
+        del self.calling_args['self']
+        
         self.msg_log(u'http_call request: {0}'.format(url))
 
         self.blocking_mode = blocking
@@ -335,7 +336,18 @@ class NetworkAccessManager(object):
 
                 self.reply.deleteLater()
                 self.reply = None
-                self.request(redirectionUrl.toString())
+                
+                if self.calling_args['redirections'] <= 0:
+                    return
+                
+                new_request = {}
+                request_changes = { 'url': redirectionUrl.toString(),
+                                    'redirections': self.calling_args['redirections']-1 }
+                new_request.update(self.calling_args)
+                new_request.update(request_changes)
+                
+                # we want to skip the "normal" end of request on a redirect
+                return self.request(**new_request)
 
             # really end request
             else:


### PR DESCRIPTION
Hi folks, I noticed that redirections weren't being handled properly when I was using this library - they would result in an error, due to an attempt to access `self.reply` when it was set to `None`, and I noticed that other request arguments would revert to defaults on the redirect call as well.

Have added some simple fixes which have been sufficient for my needs. You may or may not want to use as-is but I thought my fixes would be useful as an illustration of the issues either way.